### PR TITLE
Fix Black errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ tests: install
 .PHONY: black-check
 black-check:
 	$(PIP) install black > black-install.log
-	black --check .
+	black --check --diff .
 
 ## black:
 ##	uses black to reformat the python files, if needed

--- a/routes/index.py
+++ b/routes/index.py
@@ -567,7 +567,6 @@ def figurePopularProjects(data):
 
 
 def figureEggBaskets(data, supplementary_data):
-
     eggs_days_ago = 90
     if supplementary_data.rates.empty:
         yAxisTitle = "Sum of billable time"
@@ -638,7 +637,6 @@ if SHOWTAB_POPULAR_PROJECTS:
 # Financial data
 # Requires income and costs in config files
 if "Real_income" in supplementary_data.costs:
-
     max_year = int(supplementary_data.raw_costs[supplementary_data.raw_costs["Real_income"] != 0]["Year"].max())
 
     figures = [figureFinancialTotal(year) for year in range(START_DATE.year, max_year + 1)]

--- a/tests/test_notion.py
+++ b/tests/test_notion.py
@@ -6,7 +6,6 @@ import routes.notion as notion
 
 class TestNotion(unittest.TestCase):
     def test_fetch_data(self):
-
         os.environ.pop("NOTION_KEY", None)
 
         with self.assertRaises(SystemExit) as cm:


### PR DESCRIPTION
Black is failing the build because of unnecessary newlines.
Not sure why it's not picking them up locally, but that's for later.