### PR TITLE
Fix issue with running without optional variables

### DIFF
--- a/metrics/index.py
+++ b/metrics/index.py
@@ -766,8 +766,8 @@ if not supplementary_data.working_hours.empty:
 
 
 # ---------------------------------------------------------
-# Normalised working time
-# Requires config files: workinghours
+# Break even
+# Requires config files: workinghours, rates, finances
 if not supplementary_data.working_hours.empty and not supplementary_data.rates.empty and not supplementary_data.costs.empty and not df_comparison.empty:
     # Add tab
     if SHOWTAB_COMPARISON:

--- a/metrics/index.py
+++ b/metrics/index.py
@@ -213,7 +213,6 @@ if not supplementary_data.working_hours.empty:
             df_comparison = df_team_earn_rolling_total.merge(df_team_normalised, how="inner", on="Date")
             delta("Comparison")
 
-
 # =========================================================
 # Figure: Comparing normalized worktime with normalized income
 # =========================================================
@@ -769,7 +768,7 @@ if not supplementary_data.working_hours.empty:
 # ---------------------------------------------------------
 # Normalised working time
 # Requires config files: workinghours
-if not df_comparison.empty:
+if not supplementary_data.working_hours.empty and not supplementary_data.rates.empty and not supplementary_data.costs.empty and not df_comparison.empty:
     # Add tab
     if SHOWTAB_COMPARISON:
         figure_tabs["comparison"] = (


### PR DESCRIPTION
If any of the work hours (Notion), rates config (/tempo folder), or finances data (Notion) are missing then `df_comparison` is never set, so the check for it being empty errors.

This simply confirms those exist.

I'd prefer to check that `df_comparison` has been set, but that is slightly more awkward given the current style of the code.