### PR TITLE
Display Allocation data from Notion

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Docker for Windows satisfies the Docker requirement.
 | **NOTION_OKR_LABELS** <br/> (optional) | *Requires: NOTION_KEY and NOTION_OKR_DATABASE_ID* <br/> The labels used in Notion. |
 | **NOTION_FINANCIAL_DATABASE_ID** <br/> (optional) | *Requires: NOTION_KEY* <br/> Like the example of *NOTION_OKR_DATABASE*, a database ID from notion is needed. The database should include the column names `Month`, `cost`, `total-cost-b2b`, and `total-income`. |
 | **NOTION_WORKINGHOURS_DATABASE_ID** <br/> (optional) | *Requires: NOTION_KEY* <br/> Like the example of *NOTION_OKR_DATABASE*, a database ID from notion is needed. The database should include the column names `User`, `Daily`, `Delta`, `Start`, and `Stop`. |
+| **NOTION_ALLOCATIONS_DATABASE_ID** <br/> (optional) | *Requires: NOTION_KEY* <br/> Like the example of *NOTION_OKR_DATABASE*, a database ID from notion is needed. The database should include the column names `Allocation`, `Assign`, and `Date` (as a date range). |
 
 ## Configuration files
 

--- a/metrics/notion.py
+++ b/metrics/notion.py
@@ -55,6 +55,28 @@ class WorkingHours(Notion):
         self.data = data.sort_values(by=["User"])
 
 
+class Allocations(Notion):
+    data: pd.DataFrame
+
+    def __init__(self, token: Optional[str] = None, database_id: str = "") -> None:
+        super().__init__(token, database_id)
+
+    def get_allocations(self) -> None:
+        result_dict = self.fetch_data(self.database_id).json()
+        data = pd.DataFrame(columns=["User", "Allocation", "Start", "Stop"])
+
+        for item in result_dict["results"]:
+            user = item["properties"]["Assign"]["people"][0]["name"]
+            allocation = item["properties"]["Allocation"]["number"]
+            start = item["properties"]["Date"]["date"]["start"]
+            stop = item["properties"]["Date"]["date"]["end"]
+
+            data.loc[-1] = [user, allocation, start, stop]
+            data.index = data.index + 1
+
+        self.data = data.sort_values(by=["User"])
+
+
 class Financials(Notion):
     data: pd.DataFrame
 


### PR DESCRIPTION
Retrieve Allocation data from Notion and show a graph of the total allocations over time per user

Depends (chains) on #222 